### PR TITLE
Fix possible bug with opcode fallback

### DIFF
--- a/Sources/DiscordGateway/BotGatewayManager.swift
+++ b/Sources/DiscordGateway/BotGatewayManager.swift
@@ -814,10 +814,8 @@ extension BotGatewayManager {
                 return
             }
             Task {
-                let opcode: WebSocketOpcode =
-                    message.opcode ?? .init(
-                        encodedWebSocketOpcode: message.payload.opcode.rawValue
-                    )!
+                // If the message has no specified opcode, default to sending .text
+                let opcode: WebSocketOpcode = message.opcode ?? .text
 
                 let data: Data
                 do {


### PR DESCRIPTION
<!-- Thanks in advance for the PR! -->
<!-- Please make sure you've followed DiscordBM's contributing guidelines. -->
<!-- Describe your changes clearly and use examples if possible. -->

This change fixes some some jank behaviour with how the raw value of Discord opcodes is used to initialise a WS opcode in the scenario that the BotGatewayManager's ``Message`` type's WS opcode property is nil.

There are two cases where this behaviour is relied upon,
the ``sendIdentify`` method:
```swift
private func sendIdentify() async {
    connectionBackoff.willTry()
    let identify = Gateway.Event(
        opcode: .identify,
        data: .identify(identifyPayload)
    )
    self.send(message: .init(payload: identify))
}
```
and the ``sendPing`` method:
```swift
private func sendPing(forConnectionWithId connectionId: UInt) {
   // ...
    self.send(
        message: .init(
            payload: .init(
                opcode: .heartbeat,
                data: .heartbeat(lastSequenceNumber: self.sequenceNumber)
            )
        )
    )
    // ...
}
```

The above snippets omit the ``opcode`` argument and so the ``Message`` type has a nil opcode. 
The line modified:
```swift
let opcode: WebSocketOpcode = message.opcode ?? .init(encodedWebSocketOpcode: message.payload.opcode.rawValue)!
``` 
will initialise a new WS opcode from a numerical opcode, based on the Discord opcode rawValue. For the two cases outlined above, the Discord identify opcode's underlying rawValue is valid and initialises the WS opcode .binary, and the heartbeat Discord opcode is also valid and initialises with .text. Other values for other Discord opcodes are extremely unlikely to map to a valid WS opcode and will mean the ``.init(encodedWebSocketOpcode:)`` initialiser will return nil, be force unwrapped and cause a crash.

A way to alleviate this is to specify the opcodes manually in each initialised ``Message``, which avoids this codepath, but this doesn't fix the problem which is then left to human error to trigger. A more suitable fallback is .text as Discord mentions all payloads should be sent as UTF-8 text. If you want to remain functionally identical, add `opcode: .binary` to the identify payload. The heartbeat payload will use the fallback .text path which is what it already was prior to the change proposed. 