### PR TITLE
Components v2 payloads

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "322f70ca72bc07f8acf9597ad285151bd968104a2800d9ec87baa1c1e4f9f073",
+  "originHash" : "04d6882740e41c541c7c88310dd4dc411f3f5e9b055e4e4e4bdaea15b2ca5e1b",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/swift-websocket.git",
       "state" : {
-        "revision" : "23dbd30eda344c04268660d7c2db4c15f818639d",
-        "version" : "1.6.0"
+        "revision" : "126df9655565068bd97838c072c1db11f9fd42ee",
+        "version" : "1.6.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.1"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"605.0.0"),
         .package(url: "https://github.com/facebook/zstd.git", from: "1.5.7"),
-        .package(url: "https://github.com/hummingbird-project/swift-websocket.git", from: "1.4.0"),
+        .package(url: "https://github.com/hummingbird-project/swift-websocket.git", from: "1.6.1"),
     ],
     targets: [
         .target(

--- a/Sources/DiscordModels/Protocols/ValidatablePayload/ValidatablePayload.swift
+++ b/Sources/DiscordModels/Protocols/ValidatablePayload/ValidatablePayload.swift
@@ -212,7 +212,7 @@ extension ValidatablePayload {
     ) -> [ValidationFailure] {
         guard flags?.contains(.isComponentsV2) ?? false else { return [] }
 
-        func countComponents(_ components: [Interaction.ActionRow.Component]?) -> Int {
+        func componentsCount(_ components: [Interaction.ActionRow.Component]?) -> Int {
             (components ?? []).reduce(into: 0) { result, element in
                 result += 1
                 switch element {
@@ -222,35 +222,35 @@ extension ValidatablePayload {
                     .__undocumented:
                     break
                 case .section(let section):
-                    result += countComponents(section.components)
-                    result += countComponents([section.accessory])
+                    result += componentsCount(section.components)
+                    result += componentsCount([section.accessory])
                 case .container(let container):
                     if let containerComponents = container.componentsV2 {
-                        result += countComponents(containerComponents)
+                        result += componentsCount(containerComponents)
                     } else {
-                        result += countComponents(container.components)
+                        result += componentsCount(container.components)
                     }
                 }
             }
         }
 
-        func countComponents(_ components: [Interaction.MessageLayoutComponent]) -> Int {
+        func componentsCount(_ components: [Interaction.MessageLayoutComponent]) -> Int {
             components.reduce(into: 0) { result, element in
                 switch element {
                 case let .actionRow(actionRow):
-                    result += 1 + countComponents(actionRow.components)
+                    result += 1 + componentsCount(actionRow.components)
                 case let .component(component):
-                    result += countComponents([component])
+                    result += componentsCount([component])
                 }
             }
         }
 
         let componentCount: Int
         if let componentsV2 {
-            componentCount = countComponents(componentsV2)
+            componentCount = componentsCount(componentsV2)
         } else {
             componentCount = (components ?? []).reduce(into: 0) { result, element in
-                result += 1 + countComponents(element.components)
+                result += 1 + componentsCount(element.components)
             }
         }
 

--- a/Sources/DiscordModels/Protocols/ValidatablePayload/ValidatablePayload.swift
+++ b/Sources/DiscordModels/Protocols/ValidatablePayload/ValidatablePayload.swift
@@ -177,8 +177,21 @@ extension ValidatablePayload {
     }
 
     @inlinable
+    func validateUniqueCustomIDs(_ customIDs: [String]) -> ValidationFailure? {
+        guard Set(customIDs).count == customIDs.count else {
+            return .containsProhibitedValues(
+                name: "custom_id",
+                reason: "Must be unique within the message or modal",
+                valuesRepresentation: "\(customIDs)"
+            )
+        }
+        return nil
+    }
+
+    @inlinable
     func validateComponentsV2Payload(
         components: [Interaction.ActionRow]?,
+        componentsV2: [Interaction.MessageLayoutComponent]? = nil,
         flags: IntBitField<DiscordChannel.Message.Flag>?,
         hasContent: Bool,
         hasEmbeds: Bool,
@@ -187,27 +200,50 @@ extension ValidatablePayload {
     ) -> [ValidationFailure] {
         guard flags?.contains(.isComponentsV2) ?? false else { return [] }
 
-        func componentsCount(_ components: [Interaction.ActionRow.Component]?) -> Int {
+        func countComponents(_ components: [Interaction.ActionRow.Component]?) -> Int {
             (components ?? []).reduce(into: 0) { result, element in
+                result += 1
                 switch element {
                 case .button, .stringSelect, .textInput, .userSelect, .roleSelect, .mentionableSelect,
                     .channelSelect, .textDisplay, .thumbnail, .mediaGallery, .file, .separator,
-                    .container, .label, .fileUpload, .radioGroup, .checkboxGroup, .checkbox,
+                    .label, .fileUpload, .radioGroup, .checkboxGroup, .checkbox,
                     .__undocumented:
                     result += 1
                 case .section(let section):
-                    result += componentsCount(section.components)
+                    result += countComponents(section.components)
+                case .container(let container):
+                    if let containerComponents = container.componentsV2 {
+                        result += countComponents(containerComponents)
+                    } else {
+                        result += countComponents(container.components)
+                    }
                 }
             }
         }
 
-        let componentsCount = (components ?? []).reduce(into: 0) { result, element in
-            result += componentsCount(element.components)
+        func countComponents(_ components: [Interaction.MessageLayoutComponent]) -> Int {
+            components.reduce(into: 0) { result, element in
+                switch element {
+                case let .actionRow(actionRow):
+                    result += 1 + countComponents(actionRow.components)
+                case let .component(component):
+                    result += countComponents([component])
+                }
+            }
+        }
+
+        let componentCount: Int
+        if let componentsV2 {
+            componentCount = countComponents(componentsV2)
+        } else {
+            componentCount = (components ?? []).reduce(into: 0) { result, element in
+                result += 1 + countComponents(element.components)
+            }
         }
 
         var failures: [ValidationFailure] = []
 
-        if let failure = validateNumberInRangeOrNil(componentsCount, min: 0, max: 40, name: "components.count") {
+        if let failure = validateNumberInRangeOrNil(componentCount, min: 0, max: 40, name: "components.count") {
             failures.append(failure)
         }
 

--- a/Sources/DiscordModels/Protocols/ValidatablePayload/ValidatablePayload.swift
+++ b/Sources/DiscordModels/Protocols/ValidatablePayload/ValidatablePayload.swift
@@ -245,18 +245,23 @@ extension ValidatablePayload {
             }
         }
 
-        let componentCount: Int
+        let totalComponentCount: Int
         if let componentsV2 {
-            componentCount = componentsCount(componentsV2)
+            totalComponentCount = componentsCount(componentsV2)
         } else {
-            componentCount = (components ?? []).reduce(into: 0) { result, element in
+            totalComponentCount = (components ?? []).reduce(into: 0) { result, element in
                 result += 1 + componentsCount(element.components)
             }
         }
 
         var failures: [ValidationFailure] = []
 
-        if let failure = validateNumberInRangeOrNil(componentCount, min: 0, max: 40, name: "components.count") {
+        if let failure = validateNumberInRangeOrNil(
+            totalComponentCount,
+            min: 0,
+            max: 40,
+            name: "components.count"
+        ) {
             failures.append(failure)
         }
 

--- a/Sources/DiscordModels/Protocols/ValidatablePayload/ValidatablePayload.swift
+++ b/Sources/DiscordModels/Protocols/ValidatablePayload/ValidatablePayload.swift
@@ -189,6 +189,18 @@ extension ValidatablePayload {
     }
 
     @inlinable
+    func validateUniqueComponentIDs(_ componentIDs: [Int]) -> ValidationFailure? {
+        guard Set(componentIDs).count == componentIDs.count else {
+            return .containsProhibitedValues(
+                name: "id",
+                reason: "Must be unique within the message or modal",
+                valuesRepresentation: "\(componentIDs)"
+            )
+        }
+        return nil
+    }
+
+    @inlinable
     func validateComponentsV2Payload(
         components: [Interaction.ActionRow]?,
         componentsV2: [Interaction.MessageLayoutComponent]? = nil,
@@ -208,9 +220,10 @@ extension ValidatablePayload {
                     .channelSelect, .textDisplay, .thumbnail, .mediaGallery, .file, .separator,
                     .label, .fileUpload, .radioGroup, .checkboxGroup, .checkbox,
                     .__undocumented:
-                    result += 1
+                    break
                 case .section(let section):
                     result += countComponents(section.components)
+                    result += countComponents([section.accessory])
                 case .container(let container):
                     if let containerComponents = container.componentsV2 {
                         result += countComponents(containerComponents)

--- a/Sources/DiscordModels/Types/Channel.swift
+++ b/Sources/DiscordModels/Types/Channel.swift
@@ -515,7 +515,11 @@ extension DiscordChannel {
 
 @propertyWrapper
 public struct IncomingMessageComponents: Sendable, Codable {
-    public var wrappedValue: [Interaction.ActionRow]?
+    public var wrappedValue: [Interaction.ActionRow]? {
+        didSet {
+            componentsV2 = nil
+        }
+    }
     public var projectedValue: Self {
         get { self }
         set { self = newValue }
@@ -542,11 +546,10 @@ public struct IncomingMessageComponents: Sendable, Codable {
                 guard case let .actionRow(actionRow) = $0 else { return nil }
                 return actionRow
             }
-            self.componentsV2 = nil
         } else {
             self.wrappedValue = nil
-            self.componentsV2 = components
         }
+        self.componentsV2 = components
     }
 
     public func encode(to encoder: any Encoder) throws {

--- a/Sources/DiscordModels/Types/Channel.swift
+++ b/Sources/DiscordModels/Types/Channel.swift
@@ -445,7 +445,10 @@ extension DiscordChannel {
         public var referenced_message: DereferenceBox<Message>?
         public var interaction: MessageInteraction?
         public var thread: DiscordChannel?
-        public var components: [Interaction.ActionRow]?
+        @IncomingMessageComponents public var components: [Interaction.ActionRow]?
+        public var componentsV2: [Interaction.MessageLayoutComponent]? {
+            $components.componentsV2
+        }
         public var sticker_items: [StickerItem]?
         public var stickers: [Sticker]?
         public var position: Int?
@@ -493,7 +496,10 @@ extension DiscordChannel {
         public var interaction_metadata: DiscordChannel.Message.InteractionMetadata?
         public var interaction: MessageInteraction?
         public var thread: DiscordChannel?
-        public var components: [Interaction.ActionRow]?
+        @IncomingMessageComponents public var components: [Interaction.ActionRow]?
+        public var componentsV2: [Interaction.MessageLayoutComponent]? {
+            $components.componentsV2
+        }
         public var sticker_items: [StickerItem]?
         public var stickers: [Sticker]?
         public var position: Int?
@@ -504,6 +510,57 @@ extension DiscordChannel {
         /// Extra fields:
         public var member: Guild.PartialMember?
         public var guild_id: GuildSnowflake?
+    }
+}
+
+@propertyWrapper
+public struct IncomingMessageComponents: Sendable, Codable {
+    public var wrappedValue: [Interaction.ActionRow]?
+    public var projectedValue: Self {
+        get { self }
+        set { self = newValue }
+    }
+    public private(set) var componentsV2: [Interaction.MessageLayoutComponent]?
+
+    public init(wrappedValue: [Interaction.ActionRow]?) {
+        self.wrappedValue = wrappedValue
+        self.componentsV2 = nil
+    }
+
+    public init(componentsV2: [Interaction.MessageLayoutComponent]) {
+        self.wrappedValue = nil
+        self.componentsV2 = componentsV2
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let components = try [Interaction.MessageLayoutComponent](from: decoder)
+        if components.allSatisfy({
+            if case .actionRow = $0 { return true }
+            return false
+        }) {
+            self.wrappedValue = components.compactMap {
+                guard case let .actionRow(actionRow) = $0 else { return nil }
+                return actionRow
+            }
+            self.componentsV2 = nil
+        } else {
+            self.wrappedValue = nil
+            self.componentsV2 = components
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        if let componentsV2 {
+            try componentsV2.encode(to: encoder)
+        } else {
+            try wrappedValue.encode(to: encoder)
+        }
+    }
+}
+
+extension KeyedDecodingContainer {
+    func decode(_ type: IncomingMessageComponents.Type, forKey key: Key) throws -> IncomingMessageComponents {
+        try decodeIfPresent(type, forKey: key) ?? IncomingMessageComponents(wrappedValue: nil)
     }
 }
 

--- a/Sources/DiscordModels/Types/Gateway.swift
+++ b/Sources/DiscordModels/Types/Gateway.swift
@@ -1226,7 +1226,10 @@ public struct Gateway: Sendable, Codable {
         public var interaction_metadata: DiscordChannel.Message.InteractionMetadata?
         public var interaction: MessageInteraction?
         public var thread: DiscordChannel?
-        public var components: [Interaction.ActionRow]?
+        @IncomingMessageComponents public var components: [Interaction.ActionRow]?
+        public var componentsV2: [Interaction.MessageLayoutComponent]? {
+            $components.componentsV2
+        }
         public var sticker_items: [StickerItem]?
         public var stickers: [Sticker]?
         public var position: Int?
@@ -1294,7 +1297,11 @@ public struct Gateway: Sendable, Codable {
             }
             self.interaction = partialMessage.interaction
             self.thread = partialMessage.thread
-            self.components = partialMessage.components
+            if let componentsV2 = partialMessage.componentsV2 {
+                self.$components = .init(componentsV2: componentsV2)
+            } else {
+                self.components = partialMessage.components
+            }
             self.sticker_items = partialMessage.sticker_items
             self.stickers = partialMessage.stickers
             self.position = partialMessage.position

--- a/Sources/DiscordModels/Types/Gateway.swift
+++ b/Sources/DiscordModels/Types/Gateway.swift
@@ -1297,11 +1297,7 @@ public struct Gateway: Sendable, Codable {
             }
             self.interaction = partialMessage.interaction
             self.thread = partialMessage.thread
-            if let componentsV2 = partialMessage.componentsV2 {
-                self.$components = .init(componentsV2: componentsV2)
-            } else {
-                self.components = partialMessage.components
-            }
+            self.$components = partialMessage.$components
             self.sticker_items = partialMessage.sticker_items
             self.stickers = partialMessage.stickers
             self.position = partialMessage.position

--- a/Sources/DiscordModels/Types/IncomingModalComponents.swift
+++ b/Sources/DiscordModels/Types/IncomingModalComponents.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@propertyWrapper
+public struct IncomingModalComponents: Sendable, Codable {
+    public var wrappedValue: [Interaction.ActionRow]
+    public var projectedValue: Self {
+        get { self }
+        set { self = newValue }
+    }
+    public private(set) var componentsV2: [Interaction.ModalComponent]?
+
+    public init(wrappedValue: [Interaction.ActionRow]) {
+        self.wrappedValue = wrappedValue
+        self.componentsV2 = nil
+    }
+
+    public init(componentsV2: [Interaction.ModalComponent]) {
+        self.wrappedValue = []
+        self.componentsV2 = componentsV2
+    }
+
+    public init(from decoder: any Decoder) throws {
+        if let components = try? [Interaction.ActionRow](from: decoder) {
+            self.wrappedValue = components
+            self.componentsV2 = nil
+        } else {
+            self.wrappedValue = []
+            self.componentsV2 = try [Interaction.ModalComponent](from: decoder)
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        if let componentsV2 {
+            try componentsV2.encode(to: encoder)
+        } else {
+            try wrappedValue.encode(to: encoder)
+        }
+    }
+}
+
+extension KeyedDecodingContainer {
+    func decode(_ type: IncomingModalComponents.Type, forKey key: Key) throws -> IncomingModalComponents {
+        try decodeIfPresent(type, forKey: key) ?? IncomingModalComponents(wrappedValue: [])
+    }
+}

--- a/Sources/DiscordModels/Types/IncomingModalComponents.swift
+++ b/Sources/DiscordModels/Types/IncomingModalComponents.swift
@@ -2,7 +2,11 @@ import Foundation
 
 @propertyWrapper
 public struct IncomingModalComponents: Sendable, Codable {
-    public var wrappedValue: [Interaction.ActionRow]
+    public var wrappedValue: [Interaction.ActionRow] {
+        didSet {
+            componentsV2 = nil
+        }
+    }
     public var projectedValue: Self {
         get { self }
         set { self = newValue }

--- a/Sources/DiscordModels/Types/Interaction.swift
+++ b/Sources/DiscordModels/Types/Interaction.swift
@@ -706,6 +706,10 @@ extension Interaction {
                     )
                 }
             }
+
+            func validateAsComponentsV2() -> [ValidationFailure] {
+                validate()
+            }
         }
 
         /// https://discord.com/developers/docs/components/reference#string-select
@@ -1900,6 +1904,26 @@ extension Interaction {
                     Optional<ValidationFailure>.none
                 }
             }
+
+            func validateAsComponentsV2() -> [ValidationFailure] {
+                switch self {
+                case let .button(button):
+                    return button.validateAsComponentsV2()
+                case let .section(section):
+                    return section.components.flatMap { $0.validateAsComponentsV2() }
+                        + section.accessory.validateAsComponentsV2()
+                case let .container(container):
+                    if let componentsV2 = container.componentsV2 {
+                        return componentsV2.flatMap { $0.validateAsComponentsV2() }
+                    } else {
+                        return container.components.flatMap { $0.validateAsComponentsV2() }
+                    }
+                case let .label(label):
+                    return label.component.validateAsComponentsV2()
+                default:
+                    return validate()
+                }
+            }
         }
 
         public var components: [Component]
@@ -1965,7 +1989,19 @@ extension Interaction {
         }
 
         public func validate() -> [ValidationFailure] {
-            validateElementCountInRange(components, min: 1, max: 5, name: "components")
+            components.validate()
+        }
+
+        func validateAsComponentsV2() -> [ValidationFailure] {
+            var failures: [ValidationFailure] = []
+            if let failure = validateElementCountInRange(
+                components,
+                min: 1,
+                max: 5,
+                name: "components"
+            ) {
+                failures.append(failure)
+            }
             let hasOnlyButtons = components.allSatisfy {
                 if case .button = $0 { return true }
                 return false
@@ -1980,13 +2016,16 @@ extension Interaction {
                         return false
                     }
                 }
-            validateHasPrecondition(
+            if let failure = validateHasPrecondition(
                 condition: !hasOnlyButtons && !hasSingleSelect,
                 allowedIf: false,
                 name: "components",
                 reason: "Must contain up to five buttons or one select component"
-            )
-            components.validate()
+            ) {
+                failures.append(failure)
+            }
+            failures += components.flatMap { $0.validateAsComponentsV2() }
+            return failures
         }
     }
 
@@ -2027,6 +2066,15 @@ extension Interaction {
                 actionRow.validate()
             case let .component(component):
                 component.validate()
+            }
+        }
+
+        func validateAsComponentsV2() -> [ValidationFailure] {
+            switch self {
+            case let .actionRow(actionRow):
+                return actionRow.validateAsComponentsV2()
+            case let .component(component):
+                return component.validateAsComponentsV2()
             }
         }
 
@@ -2106,16 +2154,17 @@ extension Interaction {
                 Optional<ValidationFailure>.none
             }
         }
+
     }
 }
 
 extension Array where Element == Interaction.MessageLayoutComponent {
     func validateAsMessageComponents() -> [ValidationFailure] {
-        flatMap { $0.validateAsMessageComponent() }
+        flatMap { $0.validateAsMessageComponent() + $0.validateAsComponentsV2() }
     }
 
     func validateAsContainerChildren() -> [ValidationFailure] {
-        flatMap { $0.validateAsContainerChild() }
+        flatMap { $0.validateAsContainerChild() + $0.validateAsComponentsV2() }
     }
 
     func customIDs() -> [String] {

--- a/Sources/DiscordModels/Types/Interaction.swift
+++ b/Sources/DiscordModels/Types/Interaction.swift
@@ -223,7 +223,10 @@ public struct Interaction: Sendable, Codable {
     /// https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure
     public struct ModalSubmit: Sendable, Codable {
         public var custom_id: String
-        public var components: [ActionRow]
+        @IncomingModalComponents public var components: [ActionRow]
+        public var componentsV2: [ModalComponent]? {
+            $components.componentsV2
+        }
         public var resolved: Interaction.ApplicationCommand.ResolvedData?
     }
 

--- a/Sources/DiscordModels/Types/Interaction.swift
+++ b/Sources/DiscordModels/Types/Interaction.swift
@@ -679,6 +679,32 @@ extension Interaction {
                 validateCharacterCountDoesNotExceed(label, max: 80, name: "label")
                 validateCharacterCountInRangeOrNil(custom_id, min: 1, max: 100, name: "custom_id")
                 validateCharacterCountDoesNotExceed(url, max: 512, name: "url")
+                switch style {
+                case .link:
+                    validateAssertIsNotEmpty(url != nil, name: "url")
+                    validateHasPrecondition(
+                        condition: custom_id != nil || sku_id != nil,
+                        allowedIf: false,
+                        name: "custom_id,sku_id",
+                        reason: "Link buttons cannot contain 'custom_id' or 'sku_id'"
+                    )
+                case .premium:
+                    validateAssertIsNotEmpty(sku_id != nil, name: "sku_id")
+                    validateHasPrecondition(
+                        condition: custom_id != nil || label != nil || url != nil || emoji != nil,
+                        allowedIf: false,
+                        name: "custom_id,label,url,emoji",
+                        reason: "Premium buttons can only contain 'sku_id'"
+                    )
+                case .primary, .secondary, .success, .danger, .__undocumented:
+                    validateAssertIsNotEmpty(custom_id != nil, name: "custom_id")
+                    validateHasPrecondition(
+                        condition: url != nil || sku_id != nil,
+                        allowedIf: false,
+                        name: "url,sku_id",
+                        reason: "Non-link buttons cannot contain 'url' or 'sku_id'"
+                    )
+                }
             }
         }
 
@@ -1102,6 +1128,7 @@ extension Interaction {
         public struct Container: Sendable, Codable, ValidatablePayload {
             public var id: Int?
             public var components: [Component]
+            public var componentsV2: [MessageLayoutComponent]? = nil
             public var accent_color: DiscordColor?
             public var spoiler: Bool?
 
@@ -1117,8 +1144,61 @@ extension Interaction {
                 self.spoiler = spoiler
             }
 
+            public init(
+                id: Int? = nil,
+                componentsV2: [MessageLayoutComponent],
+                accent_color: DiscordColor? = nil,
+                spoiler: Bool? = nil
+            ) {
+                self.id = id
+                self.components = []
+                self.componentsV2 = componentsV2
+                self.accent_color = accent_color
+                self.spoiler = spoiler
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case id
+                case components
+                case accent_color
+                case spoiler
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.id = try container.decodeIfPresent(Int.self, forKey: .id)
+                self.accent_color = try container.decodeIfPresent(DiscordColor.self, forKey: .accent_color)
+                self.spoiler = try container.decodeIfPresent(Bool.self, forKey: .spoiler)
+                if let components = try? container.decode([Component].self, forKey: .components) {
+                    self.components = components
+                    self.componentsV2 = nil
+                } else {
+                    self.components = []
+                    self.componentsV2 = try container.decode([MessageLayoutComponent].self, forKey: .components)
+                }
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeIfPresent(id, forKey: .id)
+                if let componentsV2 {
+                    try container.encode(componentsV2, forKey: .components)
+                } else {
+                    try container.encode(components, forKey: .components)
+                }
+                try container.encodeIfPresent(accent_color, forKey: .accent_color)
+                try container.encodeIfPresent(spoiler, forKey: .spoiler)
+            }
+
             public func validate() -> [ValidationFailure] {
+                componentsV2 != nil && !components.isEmpty
+                    ? ValidationFailure.disallowedField(
+                        name: "components",
+                        reason: "Cannot be used with 'componentsV2'"
+                    )
+                    : nil
                 components.validate()
+                componentsV2?.validateAsContainerChildren()
             }
         }
 
@@ -1145,6 +1225,56 @@ extension Interaction {
                 validateCharacterCountDoesNotExceed(label, max: 45, name: "label")
                 validateCharacterCountDoesNotExceed(description, max: 100, name: "description")
                 component.validate()
+            }
+
+            func validateAsModalLabel() -> [ValidationFailure] {
+                var failures = validate()
+                switch component {
+                case .textInput, .stringSelect, .userSelect, .roleSelect, .mentionableSelect,
+                    .channelSelect, .fileUpload, .radioGroup, .checkboxGroup, .checkbox,
+                    .__undocumented:
+                    break
+                default:
+                    failures.append(
+                        .containsProhibitedValues(
+                            name: "component",
+                            reason: "Contains a component that cannot be used in a modal label",
+                            valuesRepresentation: "\(component)"
+                        )
+                    )
+                }
+                switch component {
+                case let .stringSelect(value):
+                    if let failure = validateHasPrecondition(
+                        condition: value.disabled != nil,
+                        allowedIf: false,
+                        name: "disabled",
+                        reason: "Cannot be used in a modal"
+                    ) {
+                        failures.append(failure)
+                    }
+                case let .userSelect(value), let .roleSelect(value), let .mentionableSelect(value):
+                    if let failure = validateHasPrecondition(
+                        condition: value.disabled != nil,
+                        allowedIf: false,
+                        name: "disabled",
+                        reason: "Cannot be used in a modal"
+                    ) {
+                        failures.append(failure)
+                    }
+                case let .channelSelect(value):
+                    if let failure = validateHasPrecondition(
+                        condition: value.disabled != nil,
+                        allowedIf: false,
+                        name: "disabled",
+                        reason: "Cannot be used in a modal"
+                    ) {
+                        failures.append(failure)
+                    }
+                default:
+                    break
+                }
+                return failures
             }
         }
 
@@ -1835,8 +1965,219 @@ extension Interaction {
         }
 
         public func validate() -> [ValidationFailure] {
+            validateElementCountInRange(components, min: 1, max: 5, name: "components")
+            let hasOnlyButtons = components.allSatisfy {
+                if case .button = $0 { return true }
+                return false
+            }
+            let hasSingleSelect =
+                components.count == 1
+                && components.allSatisfy {
+                    switch $0 {
+                    case .stringSelect, .userSelect, .roleSelect, .mentionableSelect, .channelSelect:
+                        return true
+                    default:
+                        return false
+                    }
+                }
+            validateHasPrecondition(
+                condition: !hasOnlyButtons && !hasSingleSelect,
+                allowedIf: false,
+                name: "components",
+                reason: "Must contain up to five buttons or one select component"
+            )
             components.validate()
         }
+    }
+
+    /// A component that can be placed at the top level of a message or inside a Container.
+    public enum MessageLayoutComponent: Sendable, Codable, ValidatablePayload {
+        case actionRow(ActionRow)
+        case component(ActionRow.Component)
+
+        public static func section(_ value: ActionRow.Section) -> Self { .component(.section(value)) }
+        public static func textDisplay(_ value: ActionRow.TextDisplay) -> Self { .component(.textDisplay(value)) }
+        public static func mediaGallery(_ value: ActionRow.MediaGallery) -> Self { .component(.mediaGallery(value)) }
+        public static func file(_ value: ActionRow.File) -> Self { .component(.file(value)) }
+        public static func separator(_ value: ActionRow.Separator) -> Self { .component(.separator(value)) }
+        public static func container(_ value: ActionRow.Container) -> Self { .component(.container(value)) }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: ActionRow.CodingKeys.self)
+            let type = try container.decode(ActionRow.Kind.self, forKey: .type)
+            if type == .actionRow {
+                self = try .actionRow(.init(from: decoder))
+            } else {
+                self = try .component(.init(from: decoder))
+            }
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            switch self {
+            case let .actionRow(actionRow):
+                try actionRow.encode(to: encoder)
+            case let .component(component):
+                try component.encode(to: encoder)
+            }
+        }
+
+        public func validate() -> [ValidationFailure] {
+            switch self {
+            case let .actionRow(actionRow):
+                actionRow.validate()
+            case let .component(component):
+                component.validate()
+            }
+        }
+
+        func validateAsMessageComponent() -> [ValidationFailure] {
+            switch self {
+            case .actionRow, .component(.section), .component(.textDisplay), .component(.mediaGallery),
+                .component(.file), .component(.separator), .component(.container), .component(.__undocumented):
+                []
+            case .component:
+                [
+                    .containsProhibitedValues(
+                        name: "components",
+                        reason: "Contains a component that cannot be used directly in a message",
+                        valuesRepresentation: "\(self)"
+                    )
+                ]
+            }
+        }
+
+        func validateAsContainerChild() -> [ValidationFailure] {
+            switch self {
+            case .actionRow, .component(.section), .component(.textDisplay), .component(.mediaGallery),
+                .component(.file), .component(.separator), .component(.__undocumented):
+                []
+            case .component:
+                [
+                    .containsProhibitedValues(
+                        name: "components",
+                        reason: "Contains a component that cannot be used in a container",
+                        valuesRepresentation: "\(self)"
+                    )
+                ]
+            }
+        }
+    }
+
+    /// A component that can be placed at the top level of a modal.
+    public enum ModalComponent: Sendable, Codable, ValidatablePayload {
+        case textDisplay(ActionRow.TextDisplay)
+        case label(ActionRow.Label)
+        case __undocumented
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: ActionRow.Component.CodingKeys.self)
+            switch try container.decode(ActionRow.Kind.self, forKey: .type) {
+            case .textDisplay:
+                self = try .textDisplay(.init(from: decoder))
+            case .label:
+                self = try .label(.init(from: decoder))
+            case .__undocumented:
+                self = .__undocumented
+            default:
+                throw ActionRow.CodingError.unexpectedComponentKind(
+                    try container.decode(ActionRow.Kind.self, forKey: .type)
+                )
+            }
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            switch self {
+            case let .textDisplay(textDisplay):
+                try ActionRow.Component.textDisplay(textDisplay).encode(to: encoder)
+            case let .label(label):
+                try ActionRow.Component.label(label).encode(to: encoder)
+            case .__undocumented:
+                break
+            }
+        }
+
+        public func validate() -> [ValidationFailure] {
+            switch self {
+            case let .textDisplay(textDisplay):
+                textDisplay.validate()
+            case let .label(label):
+                label.validateAsModalLabel()
+            case .__undocumented:
+                Optional<ValidationFailure>.none
+            }
+        }
+    }
+}
+
+extension Array where Element == Interaction.MessageLayoutComponent {
+    func validateAsMessageComponents() -> [ValidationFailure] {
+        flatMap { $0.validateAsMessageComponent() }
+    }
+
+    func validateAsContainerChildren() -> [ValidationFailure] {
+        flatMap { $0.validateAsContainerChild() }
+    }
+
+    func customIDs() -> [String] {
+        flatMap { $0.customIDs() }
+    }
+}
+
+extension Interaction.MessageLayoutComponent {
+    func customIDs() -> [String] {
+        switch self {
+        case let .actionRow(actionRow):
+            actionRow.components.customIDs()
+        case let .component(component):
+            component.customIDs()
+        }
+    }
+}
+
+extension Interaction.ModalComponent {
+    func customIDs() -> [String] {
+        switch self {
+        case .textDisplay:
+            []
+        case let .label(label):
+            label.component.customIDs()
+        case .__undocumented:
+            []
+        }
+    }
+}
+
+extension Array where Element == Interaction.ModalComponent {
+    func customIDs() -> [String] {
+        flatMap { $0.customIDs() }
+    }
+}
+
+extension Interaction.ActionRow.Component {
+    func customIDs() -> [String] {
+        var customIDs = customId.map { [$0] } ?? []
+        switch self {
+        case let .section(section):
+            customIDs += section.components.customIDs()
+            customIDs += section.accessory.customIDs()
+        case let .container(container):
+            if let componentsV2 = container.componentsV2 {
+                customIDs += componentsV2.customIDs()
+            } else {
+                customIDs += container.components.customIDs()
+            }
+        case let .label(label):
+            customIDs += label.component.customIDs()
+        default:
+            break
+        }
+        return customIDs
+    }
+}
+
+extension Array where Element == Interaction.ActionRow.Component {
+    func customIDs() -> [String] {
+        flatMap { $0.customIDs() }
     }
 }
 

--- a/Sources/DiscordModels/Types/Interaction.swift
+++ b/Sources/DiscordModels/Types/Interaction.swift
@@ -1216,6 +1216,13 @@ extension Interaction {
             public var description: String?
             public var component: Component
 
+            enum CodingKeys: String, CodingKey {
+                case id
+                case label
+                case description
+                case component
+            }
+
             public init(
                 id: Int? = nil,
                 label: String,
@@ -1226,6 +1233,15 @@ extension Interaction {
                 self.label = label
                 self.description = description
                 self.component = component
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.id = try container.decodeIfPresent(Int.self, forKey: .id)
+                // Discord omits display-only fields from a modal submission.
+                self.label = try container.decodeIfPresent(String.self, forKey: .label) ?? ""
+                self.description = try container.decodeIfPresent(String.self, forKey: .description)
+                self.component = try container.decode(Component.self, forKey: .component)
             }
 
             public func validate() -> [ValidationFailure] {

--- a/Sources/DiscordModels/Types/Interaction.swift
+++ b/Sources/DiscordModels/Types/Interaction.swift
@@ -757,6 +757,18 @@ extension Interaction {
             public var disabled: Bool?
             public var values: [String]?
 
+            enum CodingKeys: String, CodingKey {
+                case id
+                case custom_id
+                case options
+                case placeholder
+                case min_values
+                case max_values
+                case required
+                case disabled
+                case values
+            }
+
             public init(
                 id: Int? = nil,
                 custom_id: String,
@@ -776,6 +788,20 @@ extension Interaction {
                 self.required = required
                 self.disabled = disabled
                 self.values = nil
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.id = try container.decodeIfPresent(Int.self, forKey: .id)
+                self.custom_id = try container.decode(String.self, forKey: .custom_id)
+                // Discord omits the configured options from String Select interaction responses.
+                self.options = try container.decodeIfPresent([Option].self, forKey: .options) ?? []
+                self.placeholder = try container.decodeIfPresent(String.self, forKey: .placeholder)
+                self.min_values = try container.decodeIfPresent(Int.self, forKey: .min_values)
+                self.max_values = try container.decodeIfPresent(Int.self, forKey: .max_values)
+                self.required = try container.decodeIfPresent(Bool.self, forKey: .required)
+                self.disabled = try container.decodeIfPresent(Bool.self, forKey: .disabled)
+                self.values = try container.decodeIfPresent([String].self, forKey: .values)
             }
 
             public func validate() -> [ValidationFailure] {

--- a/Sources/DiscordModels/Types/Interaction.swift
+++ b/Sources/DiscordModels/Types/Interaction.swift
@@ -1298,6 +1298,15 @@ extension Interaction {
                     )
                 }
                 switch component {
+                case let .textInput(value):
+                    if let failure = validateHasPrecondition(
+                        condition: value.label != nil,
+                        allowedIf: false,
+                        name: "component.label",
+                        reason: "Cannot set a Text Input label in a modal label"
+                    ) {
+                        failures.append(failure)
+                    }
                 case let .stringSelect(value):
                     if let failure = validateHasPrecondition(
                         condition: value.disabled != nil,

--- a/Sources/DiscordModels/Types/Interaction.swift
+++ b/Sources/DiscordModels/Types/Interaction.swift
@@ -988,6 +988,37 @@ extension Interaction {
                 components.validate()
                 accessory.validate()
             }
+
+            func validateAsComponentsV2() -> [ValidationFailure] {
+                var failures: [ValidationFailure] = []
+                for component in components {
+                    switch component {
+                    case .textDisplay, .__undocumented:
+                        break
+                    default:
+                        failures.append(
+                            .containsProhibitedValues(
+                                name: "components",
+                                reason: "Contains a component that cannot be used in a section",
+                                valuesRepresentation: "\(component)"
+                            )
+                        )
+                    }
+                }
+                switch accessory {
+                case .button, .thumbnail, .__undocumented:
+                    break
+                default:
+                    failures.append(
+                        .containsProhibitedValues(
+                            name: "accessory",
+                            reason: "Contains a component that cannot be used as a section accessory",
+                            valuesRepresentation: "\(accessory)"
+                        )
+                    )
+                }
+                return failures
+            }
         }
 
         /// https://discord.com/developers/docs/components/reference#text-display
@@ -1134,7 +1165,11 @@ extension Interaction {
         /// https://discord.com/developers/docs/components/reference#container
         public struct Container: Sendable, Codable, ValidatablePayload {
             public var id: Int?
-            public var components: [Component]
+            public var components: [Component] {
+                didSet {
+                    componentsV2 = nil
+                }
+            }
             public var componentsV2: [MessageLayoutComponent]? = nil
             public var accent_color: DiscordColor?
             public var spoiler: Bool?
@@ -1176,13 +1211,12 @@ extension Interaction {
                 self.id = try container.decodeIfPresent(Int.self, forKey: .id)
                 self.accent_color = try container.decodeIfPresent(DiscordColor.self, forKey: .accent_color)
                 self.spoiler = try container.decodeIfPresent(Bool.self, forKey: .spoiler)
-                if let components = try? container.decode([Component].self, forKey: .components) {
-                    self.components = components
-                    self.componentsV2 = nil
-                } else {
-                    self.components = []
-                    self.componentsV2 = try container.decode([MessageLayoutComponent].self, forKey: .components)
+                let componentsV2 = try container.decode([MessageLayoutComponent].self, forKey: .components)
+                self.components = componentsV2.compactMap {
+                    guard case let .component(component) = $0 else { return nil }
+                    return component
                 }
+                self.componentsV2 = componentsV2
             }
 
             public func encode(to encoder: any Encoder) throws {
@@ -1198,14 +1232,11 @@ extension Interaction {
             }
 
             public func validate() -> [ValidationFailure] {
-                componentsV2 != nil && !components.isEmpty
-                    ? ValidationFailure.disallowedField(
-                        name: "components",
-                        reason: "Cannot be used with 'componentsV2'"
-                    )
-                    : nil
-                components.validate()
-                componentsV2?.validateAsContainerChildren()
+                if let componentsV2 {
+                    componentsV2.validateAsContainerChildren()
+                } else {
+                    components.validate()
+                }
             }
         }
 
@@ -1530,6 +1561,51 @@ extension Interaction {
                 case .section, .textDisplay, .thumbnail, .mediaGallery, .file,
                     .separator, .container, .label, .fileUpload, .__undocumented:
                     return nil
+                }
+            }
+
+            public var id: Int? {
+                switch self {
+                case let .button(value):
+                    value.id
+                case let .stringSelect(value):
+                    value.id
+                case let .textInput(value):
+                    value.id
+                case let .userSelect(value):
+                    value.id
+                case let .roleSelect(value):
+                    value.id
+                case let .mentionableSelect(value):
+                    value.id
+                case let .channelSelect(value):
+                    value.id
+                case let .section(value):
+                    value.id
+                case let .textDisplay(value):
+                    value.id
+                case let .thumbnail(value):
+                    value.id
+                case let .mediaGallery(value):
+                    value.id
+                case let .file(value):
+                    value.id
+                case let .separator(value):
+                    value.id
+                case let .container(value):
+                    value.id
+                case let .label(value):
+                    value.id
+                case let .fileUpload(value):
+                    value.id
+                case let .radioGroup(value):
+                    value.id
+                case let .checkboxGroup(value):
+                    value.id
+                case let .checkbox(value):
+                    value.id
+                case .__undocumented:
+                    nil
                 }
             }
 
@@ -1929,8 +2005,7 @@ extension Interaction {
                 case let .button(button):
                     return button.validateAsComponentsV2()
                 case let .section(section):
-                    return section.components.flatMap { $0.validateAsComponentsV2() }
-                        + section.accessory.validateAsComponentsV2()
+                    return section.validateAsComponentsV2()
                 case let .container(container):
                     if let componentsV2 = container.componentsV2 {
                         return componentsV2.flatMap { $0.validateAsComponentsV2() }
@@ -1945,6 +2020,7 @@ extension Interaction {
             }
         }
 
+        public var id: Int?
         public var components: [Component]
 
         public enum CodingError: Swift.Error, CustomStringConvertible {
@@ -1965,6 +2041,7 @@ extension Interaction {
 
         enum CodingKeys: String, CodingKey {
             case type
+            case id
             case components
         }
 
@@ -1974,20 +2051,24 @@ extension Interaction {
             guard type == .actionRow else {
                 throw CodingError.unexpectedComponentKind(type)
             }
+            self.id = try container.decodeIfPresent(Int.self, forKey: .id)
             self.components = try container.decode([Component].self, forKey: .components)
         }
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(Kind.actionRow, forKey: .type)
+            try container.encodeIfPresent(id, forKey: .id)
             try container.encode(self.components, forKey: .components)
         }
 
-        public init(components: [Component]) {
+        public init(id: Int? = nil, components: [Component]) {
+            self.id = id
             self.components = components
         }
 
         public init(arrayLiteral elements: Component...) {
+            self.id = nil
             self.components = elements
         }
 
@@ -2189,6 +2270,10 @@ extension Array where Element == Interaction.MessageLayoutComponent {
     func customIDs() -> [String] {
         flatMap { $0.customIDs() }
     }
+
+    func componentIDs() -> [Int] {
+        flatMap { $0.componentIDs() }
+    }
 }
 
 extension Interaction.MessageLayoutComponent {
@@ -2198,6 +2283,15 @@ extension Interaction.MessageLayoutComponent {
             actionRow.components.customIDs()
         case let .component(component):
             component.customIDs()
+        }
+    }
+
+    func componentIDs() -> [Int] {
+        switch self {
+        case let .actionRow(actionRow):
+            actionRow.componentIDs()
+        case let .component(component):
+            component.componentIDs()
         }
     }
 }
@@ -2213,11 +2307,26 @@ extension Interaction.ModalComponent {
             []
         }
     }
+
+    func componentIDs() -> [Int] {
+        switch self {
+        case let .textDisplay(textDisplay):
+            [textDisplay.id].compactMap { $0 }
+        case let .label(label):
+            [label.id].compactMap { $0 } + label.component.componentIDs()
+        case .__undocumented:
+            []
+        }
+    }
 }
 
 extension Array where Element == Interaction.ModalComponent {
     func customIDs() -> [String] {
         flatMap { $0.customIDs() }
+    }
+
+    func componentIDs() -> [Int] {
+        flatMap { $0.componentIDs() }
     }
 }
 
@@ -2241,11 +2350,41 @@ extension Interaction.ActionRow.Component {
         }
         return customIDs
     }
+
+    func componentIDs() -> [Int] {
+        var componentIDs = [id].compactMap { $0 }
+        switch self {
+        case let .section(section):
+            componentIDs += section.components.componentIDs()
+            componentIDs += section.accessory.componentIDs()
+        case let .container(container):
+            if let componentsV2 = container.componentsV2 {
+                componentIDs += componentsV2.componentIDs()
+            } else {
+                componentIDs += container.components.componentIDs()
+            }
+        case let .label(label):
+            componentIDs += label.component.componentIDs()
+        default:
+            break
+        }
+        return componentIDs
+    }
 }
 
 extension Array where Element == Interaction.ActionRow.Component {
     func customIDs() -> [String] {
         flatMap { $0.customIDs() }
+    }
+
+    func componentIDs() -> [Int] {
+        flatMap { $0.componentIDs() }
+    }
+}
+
+extension Interaction.ActionRow {
+    func componentIDs() -> [Int] {
+        [id].compactMap { $0 } + components.componentIDs()
     }
 }
 

--- a/Sources/DiscordModels/Types/Payloads.swift
+++ b/Sources/DiscordModels/Types/Payloads.swift
@@ -6,6 +6,16 @@ import NIOFoundationCompat
 /// These types only need to be `Encodable`,
 /// unless we actually need them to be `Decodable` as well.
 public enum Payloads {
+    private static func messageFlags(
+        _ flags: IntBitField<DiscordChannel.Message.Flag>?,
+        componentsV2: [Interaction.MessageLayoutComponent]?
+    ) -> IntBitField<DiscordChannel.Message.Flag>? {
+        guard componentsV2 != nil else { return flags }
+        var flags = flags ?? []
+        flags.insert(.isComponentsV2)
+        return flags
+    }
+
     /// An attachment object, but for sending.
     /// https://docs.discord.com/developers/resources/channel#attachment-object
     public struct Attachment: Sendable, Encodable, ValidatablePayload {
@@ -127,6 +137,7 @@ public enum Payloads {
             public var allowedMentions: AllowedMentions?
             public var flags: IntBitField<DiscordChannel.Message.Flag>?
             public var components: [Interaction.ActionRow]?
+            public var componentsV2: [Interaction.MessageLayoutComponent]? = nil
             public var attachments: [Attachment]?
             public var files: [RawFile]?
             public var poll: CreatePollRequest?
@@ -164,6 +175,48 @@ public enum Payloads {
                 self.poll = poll
             }
 
+            public init(
+                tts: Bool? = nil,
+                content: String? = nil,
+                embeds: [Embed]? = nil,
+                allowedMentions: AllowedMentions? = nil,
+                flags: IntBitField<DiscordChannel.Message.Flag>? = nil,
+                componentsV2: [Interaction.MessageLayoutComponent],
+                attachments: [Attachment]? = nil,
+                files: [RawFile]? = nil,
+                poll: CreatePollRequest? = nil
+            ) {
+                self.tts = tts
+                self.content = content
+                self.embeds = embeds
+                self.allowedMentions = allowedMentions
+                self.flags = Payloads.messageFlags(flags, componentsV2: componentsV2)
+                self.components = nil
+                self.componentsV2 = componentsV2
+                self.attachments = attachments
+                self.files = files
+                self.poll = poll
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeIfPresent(tts, forKey: .tts)
+                try container.encodeIfPresent(content, forKey: .content)
+                try container.encodeIfPresent(embeds, forKey: .embeds)
+                try container.encodeIfPresent(allowedMentions, forKey: .allowedMentions)
+                try container.encodeIfPresent(
+                    Payloads.messageFlags(flags, componentsV2: componentsV2),
+                    forKey: .flags
+                )
+                if let componentsV2 {
+                    try container.encode(componentsV2, forKey: .components)
+                } else {
+                    try container.encodeIfPresent(components, forKey: .components)
+                }
+                try container.encodeIfPresent(attachments, forKey: .attachments)
+                try container.encodeIfPresent(poll, forKey: .poll)
+            }
+
             public func validate() -> [ValidationFailure] {
                 validateElementCountDoesNotExceed(embeds, max: 10, name: "embeds")
                 allowedMentions?.validate()
@@ -182,13 +235,25 @@ public enum Payloads {
                 )
                 validateComponentsV2Payload(
                     components: components,
-                    flags: flags,
+                    componentsV2: componentsV2,
+                    flags: Payloads.messageFlags(flags, componentsV2: componentsV2),
                     hasContent: !(content?.isEmpty ?? true),
                     hasEmbeds: !(embeds?.isEmpty ?? true),
                     hasStickers: false,
                     hasPoll: poll != nil
                 )
+                components != nil && componentsV2 != nil
+                    ? ValidationFailure.disallowedField(
+                        name: "components",
+                        reason: "Cannot be used with 'componentsV2'"
+                    )
+                    : nil
                 components?.validate()
+                componentsV2?.validate()
+                componentsV2?.validateAsMessageComponents()
+                validateUniqueCustomIDs(
+                    componentsV2?.customIDs() ?? components.map { $0.flatMap(\.components).customIDs() } ?? []
+                )
                 attachments?.validate()
                 embeds?.validate()
                 poll?.validate()
@@ -213,30 +278,66 @@ public enum Payloads {
             public var custom_id: String
             public var title: String
             public var components: [Interaction.ActionRow]
+            public var componentsV2: [Interaction.ModalComponent]?
 
-            /// Previously you could only send text-inputs. Now a few more new types of components are supported.
-            /// Outdated comments below:
-            ///
-            /// Discord docs says currently you can only send text-inputs.
-            /// To send other types of components, use a normal message's `components`:
-            /// `Payloads.InteractionResponse.Message(components: [...])`
-            /// Respectively, you can't send a text-input using a normal message's `components`.
             public init(custom_id: String, title: String, textInputs: [Interaction.ActionRow.TextInput]) {
                 self.custom_id = custom_id
                 self.title = title
                 self.components = textInputs.map { [.textInput($0)] }
+                self.componentsV2 = nil
             }
 
             public init(custom_id: String, title: String, components: [Interaction.ActionRow]) {
                 self.custom_id = custom_id
                 self.title = title
                 self.components = components
+                self.componentsV2 = nil
+            }
+
+            public init(
+                custom_id: String,
+                title: String,
+                componentsV2: [Interaction.ModalComponent]
+            ) {
+                self.custom_id = custom_id
+                self.title = title
+                self.components = []
+                self.componentsV2 = componentsV2
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case custom_id
+                case title
+                case components
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(custom_id, forKey: .custom_id)
+                try container.encode(title, forKey: .title)
+                if let componentsV2 {
+                    try container.encode(componentsV2, forKey: .components)
+                } else {
+                    try container.encode(components, forKey: .components)
+                }
             }
 
             public func validate() -> [ValidationFailure] {
                 validateCharacterCountInRange(custom_id, min: 1, max: 100, name: "custom_id")
-                validateElementCountInRange(components, min: 1, max: 5, name: "components")
+                if let componentsV2 {
+                    validateElementCountInRange(componentsV2, min: 1, max: 5, name: "components")
+                } else {
+                    validateElementCountInRange(components, min: 1, max: 5, name: "components")
+                }
+                componentsV2 != nil && !components.isEmpty
+                    ? ValidationFailure.disallowedField(
+                        name: "components",
+                        reason: "Cannot be used with 'componentsV2'"
+                    )
+                    : nil
                 components.validate()
+                componentsV2?.validate()
+                validateUniqueCustomIDs(componentsV2?.customIDs() ?? components.flatMap(\.components).customIDs())
             }
         }
 
@@ -447,6 +548,7 @@ public enum Payloads {
         public var allowed_mentions: AllowedMentions?
         public var message_reference: DiscordChannel.Message.MessageReference?
         public var components: [Interaction.ActionRow]?
+        public var componentsV2: [Interaction.MessageLayoutComponent]? = nil
         public var sticker_ids: [String]?
         public var files: [RawFile]?
         public var attachments: [Attachment]?
@@ -499,6 +601,60 @@ public enum Payloads {
             self.poll = poll
         }
 
+        public init(
+            content: String? = nil,
+            nonce: StringOrInt? = nil,
+            tts: Bool? = nil,
+            embeds: [Embed]? = nil,
+            allowed_mentions: AllowedMentions? = nil,
+            message_reference: DiscordChannel.Message.MessageReference? = nil,
+            componentsV2: [Interaction.MessageLayoutComponent],
+            sticker_ids: [String]? = nil,
+            files: [RawFile]? = nil,
+            attachments: [Attachment]? = nil,
+            flags: IntBitField<DiscordChannel.Message.Flag>? = nil,
+            enforce_nonce: Bool? = nil,
+            poll: CreatePollRequest? = nil
+        ) {
+            self.content = content
+            self.nonce = nonce
+            self.tts = tts
+            self.embeds = embeds
+            self.allowed_mentions = allowed_mentions
+            self.message_reference = message_reference
+            self.components = nil
+            self.componentsV2 = componentsV2
+            self.sticker_ids = sticker_ids
+            self.files = files
+            self.attachments = attachments
+            self.flags = Payloads.messageFlags(flags, componentsV2: componentsV2)
+            self.enforce_nonce = enforce_nonce
+            self.poll = poll
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(content, forKey: .content)
+            try container.encodeIfPresent(nonce, forKey: .nonce)
+            try container.encodeIfPresent(tts, forKey: .tts)
+            try container.encodeIfPresent(embeds, forKey: .embeds)
+            try container.encodeIfPresent(allowed_mentions, forKey: .allowed_mentions)
+            try container.encodeIfPresent(message_reference, forKey: .message_reference)
+            if let componentsV2 {
+                try container.encode(componentsV2, forKey: .components)
+            } else {
+                try container.encodeIfPresent(components, forKey: .components)
+            }
+            try container.encodeIfPresent(sticker_ids, forKey: .sticker_ids)
+            try container.encodeIfPresent(attachments, forKey: .attachments)
+            try container.encodeIfPresent(
+                Payloads.messageFlags(flags, componentsV2: componentsV2),
+                forKey: .flags
+            )
+            try container.encodeIfPresent(enforce_nonce, forKey: .enforce_nonce)
+            try container.encodeIfPresent(poll, forKey: .poll)
+        }
+
         public func validate() -> [ValidationFailure] {
             validateElementCountDoesNotExceed(embeds, max: 10, name: "embeds")
             validateElementCountDoesNotExceed(sticker_ids, max: 3, name: "sticker_ids")
@@ -510,6 +666,7 @@ public enum Payloads {
                 embeds?.isEmpty,
                 sticker_ids?.isEmpty,
                 components?.isEmpty,
+                componentsV2?.isEmpty,
                 files?.isEmpty,
                 poll?.answers.isEmpty,
                 message_reference == nil,
@@ -517,6 +674,7 @@ public enum Payloads {
                 "embeds",
                 "sticker_ids",
                 "components",
+                "componentsV2",
                 "files",
                 "poll",
                 "message_reference"
@@ -535,13 +693,25 @@ public enum Payloads {
             )
             validateComponentsV2Payload(
                 components: components,
-                flags: flags,
+                componentsV2: componentsV2,
+                flags: Payloads.messageFlags(flags, componentsV2: componentsV2),
                 hasContent: !(content?.isEmpty ?? true),
                 hasEmbeds: !(embeds?.isEmpty ?? true),
                 hasStickers: !(sticker_ids?.isEmpty ?? true),
                 hasPoll: poll != nil
             )
+            components != nil && componentsV2 != nil
+                ? ValidationFailure.disallowedField(
+                    name: "components",
+                    reason: "Cannot be used with 'componentsV2'"
+                )
+                : nil
             components?.validate()
+            componentsV2?.validate()
+            componentsV2?.validateAsMessageComponents()
+            validateUniqueCustomIDs(
+                componentsV2?.customIDs() ?? components.map { $0.flatMap(\.components).customIDs() } ?? []
+            )
             attachments?.validate()
             embeds?.validate()
             poll?.validate()

--- a/Sources/DiscordModels/Types/Payloads.swift
+++ b/Sources/DiscordModels/Types/Payloads.swift
@@ -251,9 +251,9 @@ public enum Payloads {
                 components?.validate()
                 componentsV2?.validate()
                 componentsV2?.validateAsMessageComponents()
-                validateUniqueCustomIDs(
-                    componentsV2?.customIDs() ?? components.map { $0.flatMap(\.components).customIDs() } ?? []
-                )
+                if let componentsV2 {
+                    validateUniqueCustomIDs(componentsV2.customIDs())
+                }
                 attachments?.validate()
                 embeds?.validate()
                 poll?.validate()
@@ -337,7 +337,9 @@ public enum Payloads {
                     : nil
                 components.validate()
                 componentsV2?.validate()
-                validateUniqueCustomIDs(componentsV2?.customIDs() ?? components.flatMap(\.components).customIDs())
+                if let componentsV2 {
+                    validateUniqueCustomIDs(componentsV2.customIDs())
+                }
             }
         }
 
@@ -709,9 +711,9 @@ public enum Payloads {
             components?.validate()
             componentsV2?.validate()
             componentsV2?.validateAsMessageComponents()
-            validateUniqueCustomIDs(
-                componentsV2?.customIDs() ?? components.map { $0.flatMap(\.components).customIDs() } ?? []
-            )
+            if let componentsV2 {
+                validateUniqueCustomIDs(componentsV2.customIDs())
+            }
             attachments?.validate()
             embeds?.validate()
             poll?.validate()

--- a/Sources/DiscordModels/Types/Payloads.swift
+++ b/Sources/DiscordModels/Types/Payloads.swift
@@ -253,6 +253,7 @@ public enum Payloads {
                 componentsV2?.validateAsMessageComponents()
                 if let componentsV2 {
                     validateUniqueCustomIDs(componentsV2.customIDs())
+                    validateUniqueComponentIDs(componentsV2.componentIDs())
                 }
                 attachments?.validate()
                 embeds?.validate()
@@ -339,6 +340,7 @@ public enum Payloads {
                 componentsV2?.validate()
                 if let componentsV2 {
                     validateUniqueCustomIDs(componentsV2.customIDs())
+                    validateUniqueComponentIDs(componentsV2.componentIDs())
                 }
             }
         }
@@ -713,6 +715,7 @@ public enum Payloads {
             componentsV2?.validateAsMessageComponents()
             if let componentsV2 {
                 validateUniqueCustomIDs(componentsV2.customIDs())
+                validateUniqueComponentIDs(componentsV2.componentIDs())
             }
             attachments?.validate()
             embeds?.validate()
@@ -727,6 +730,7 @@ public enum Payloads {
         public var flags: IntBitField<DiscordChannel.Message.Flag>?
         public var allowed_mentions: AllowedMentions?
         public var components: [Interaction.ActionRow]?
+        public var componentsV2: [Interaction.MessageLayoutComponent]? = nil
         public var files: [RawFile]?
         public var attachments: [Attachment]?
 
@@ -757,6 +761,42 @@ public enum Payloads {
             self.attachments = attachments
         }
 
+        public init(
+            content: String? = nil,
+            embeds: [Embed]? = nil,
+            flags: IntBitField<DiscordChannel.Message.Flag>? = nil,
+            allowed_mentions: AllowedMentions? = nil,
+            componentsV2: [Interaction.MessageLayoutComponent],
+            files: [RawFile]? = nil,
+            attachments: [Attachment]? = nil
+        ) {
+            self.content = content
+            self.embeds = embeds
+            self.flags = Payloads.messageFlags(flags, componentsV2: componentsV2)
+            self.allowed_mentions = allowed_mentions
+            self.components = nil
+            self.componentsV2 = componentsV2
+            self.files = files
+            self.attachments = attachments
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(content, forKey: .content)
+            try container.encodeIfPresent(embeds, forKey: .embeds)
+            try container.encodeIfPresent(
+                Payloads.messageFlags(flags, componentsV2: componentsV2),
+                forKey: .flags
+            )
+            try container.encodeIfPresent(allowed_mentions, forKey: .allowed_mentions)
+            if let componentsV2 {
+                try container.encode(componentsV2, forKey: .components)
+            } else {
+                try container.encodeIfPresent(components, forKey: .components)
+            }
+            try container.encodeIfPresent(attachments, forKey: .attachments)
+        }
+
         public func validate() -> [ValidationFailure] {
             validateElementCountDoesNotExceed(embeds, max: 10, name: "embeds")
             validateCharacterCountDoesNotExceed(content, max: 2_000, name: "content")
@@ -773,16 +813,29 @@ public enum Payloads {
             )
             validateComponentsV2Payload(
                 components: components,
-                flags: flags,
+                componentsV2: componentsV2,
+                flags: Payloads.messageFlags(flags, componentsV2: componentsV2),
                 hasContent: !(content?.isEmpty ?? true),
                 hasEmbeds: !(embeds?.isEmpty ?? true),
                 hasStickers: false,
                 hasPoll: false
             )
+            components != nil && componentsV2 != nil
+                ? ValidationFailure.disallowedField(
+                    name: "components",
+                    reason: "Cannot be used with 'componentsV2'"
+                )
+                : nil
             allowed_mentions?.validate()
             attachments?.validate()
             embeds?.validate()
             components?.validate()
+            componentsV2?.validate()
+            componentsV2?.validateAsMessageComponents()
+            if let componentsV2 {
+                validateUniqueCustomIDs(componentsV2.customIDs())
+                validateUniqueComponentIDs(componentsV2.componentIDs())
+            }
         }
     }
 
@@ -795,6 +848,7 @@ public enum Payloads {
         public var embeds: [Embed]?
         public var allowed_mentions: AllowedMentions?
         public var components: [Interaction.ActionRow]?
+        public var componentsV2: [Interaction.MessageLayoutComponent]? = nil
         public var files: [RawFile]?
         public var attachments: [Attachment]?
         public var flags: IntBitField<DiscordChannel.Message.Flag>?
@@ -847,17 +901,73 @@ public enum Payloads {
             self.poll = poll
         }
 
+        public init(
+            content: String? = nil,
+            username: String? = nil,
+            avatar_url: String? = nil,
+            tts: Bool? = nil,
+            embeds: [Embed]? = nil,
+            allowed_mentions: AllowedMentions? = nil,
+            componentsV2: [Interaction.MessageLayoutComponent],
+            files: [RawFile]? = nil,
+            attachments: [Attachment]? = nil,
+            flags: IntBitField<DiscordChannel.Message.Flag>? = nil,
+            thread_name: String? = nil,
+            applied_tags: [ForumTagSnowflake]? = nil,
+            poll: CreatePollRequest? = nil
+        ) {
+            self.content = content
+            self.username = username
+            self.avatar_url = avatar_url
+            self.tts = tts
+            self.embeds = embeds
+            self.allowed_mentions = allowed_mentions
+            self.components = nil
+            self.componentsV2 = componentsV2
+            self.files = files
+            self.attachments = attachments
+            self.flags = Payloads.messageFlags(flags, componentsV2: componentsV2)
+            self.thread_name = thread_name
+            self.applied_tags = applied_tags
+            self.poll = poll
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(content, forKey: .content)
+            try container.encodeIfPresent(username, forKey: .username)
+            try container.encodeIfPresent(avatar_url, forKey: .avatar_url)
+            try container.encodeIfPresent(tts, forKey: .tts)
+            try container.encodeIfPresent(embeds, forKey: .embeds)
+            try container.encodeIfPresent(allowed_mentions, forKey: .allowed_mentions)
+            if let componentsV2 {
+                try container.encode(componentsV2, forKey: .components)
+            } else {
+                try container.encodeIfPresent(components, forKey: .components)
+            }
+            try container.encodeIfPresent(attachments, forKey: .attachments)
+            try container.encodeIfPresent(
+                Payloads.messageFlags(flags, componentsV2: componentsV2),
+                forKey: .flags
+            )
+            try container.encodeIfPresent(thread_name, forKey: .thread_name)
+            try container.encodeIfPresent(applied_tags, forKey: .applied_tags)
+            try container.encodeIfPresent(poll, forKey: .poll)
+        }
+
         public func validate() -> [ValidationFailure] {
             validateElementCountDoesNotExceed(embeds, max: 10, name: "embeds")
             validateCharacterCountDoesNotExceed(content, max: 2_000, name: "content")
             validateAtLeastOneIsNotEmpty(
                 content?.isEmpty,
                 components?.isEmpty,
+                componentsV2?.isEmpty,
                 files?.isEmpty,
                 embeds?.isEmpty,
                 poll?.answers.isEmpty,
                 names: "content",
                 "components",
+                "componentsV2",
                 "files",
                 "embeds",
                 "poll"
@@ -875,13 +985,26 @@ public enum Payloads {
             )
             validateComponentsV2Payload(
                 components: components,
-                flags: flags,
+                componentsV2: componentsV2,
+                flags: Payloads.messageFlags(flags, componentsV2: componentsV2),
                 hasContent: !(content?.isEmpty ?? true),
                 hasEmbeds: !(embeds?.isEmpty ?? true),
                 hasStickers: false,
                 hasPoll: poll != nil
             )
+            components != nil && componentsV2 != nil
+                ? ValidationFailure.disallowedField(
+                    name: "components",
+                    reason: "Cannot be used with 'componentsV2'"
+                )
+                : nil
             components?.validate()
+            componentsV2?.validate()
+            componentsV2?.validateAsMessageComponents()
+            if let componentsV2 {
+                validateUniqueCustomIDs(componentsV2.customIDs())
+                validateUniqueComponentIDs(componentsV2.componentIDs())
+            }
             allowed_mentions?.validate()
             attachments?.validate()
             embeds?.validate()
@@ -942,8 +1065,10 @@ public enum Payloads {
     public struct EditWebhookMessage: Sendable, MultipartEncodable, ValidatablePayload {
         public var content: String?
         public var embeds: [Embed]?
+        public var flags: IntBitField<DiscordChannel.Message.Flag>?
         public var allowed_mentions: AllowedMentions?
         public var components: [Interaction.ActionRow]?
+        public var componentsV2: [Interaction.MessageLayoutComponent]? = nil
         public var files: [RawFile]?
         public var attachments: [Attachment]?
         public var poll: CreatePollRequest?
@@ -951,6 +1076,7 @@ public enum Payloads {
         enum CodingKeys: String, CodingKey {
             case content
             case embeds
+            case flags
             case allowed_mentions
             case components
             case attachments
@@ -960,6 +1086,7 @@ public enum Payloads {
         public init(
             content: String? = nil,
             embeds: [Embed]? = nil,
+            flags: IntBitField<DiscordChannel.Message.Flag>? = nil,
             allowed_mentions: AllowedMentions? = nil,
             components: [Interaction.ActionRow]? = nil,
             files: [RawFile]? = nil,
@@ -968,11 +1095,51 @@ public enum Payloads {
         ) {
             self.content = content
             self.embeds = embeds
+            self.flags = flags
             self.allowed_mentions = allowed_mentions
             self.components = components
             self.files = files
             self.attachments = attachments
             self.poll = poll
+        }
+
+        public init(
+            content: String? = nil,
+            embeds: [Embed]? = nil,
+            flags: IntBitField<DiscordChannel.Message.Flag>? = nil,
+            allowed_mentions: AllowedMentions? = nil,
+            componentsV2: [Interaction.MessageLayoutComponent],
+            files: [RawFile]? = nil,
+            attachments: [Attachment]? = nil,
+            poll: CreatePollRequest? = nil
+        ) {
+            self.content = content
+            self.embeds = embeds
+            self.flags = Payloads.messageFlags(flags, componentsV2: componentsV2)
+            self.allowed_mentions = allowed_mentions
+            self.components = nil
+            self.componentsV2 = componentsV2
+            self.files = files
+            self.attachments = attachments
+            self.poll = poll
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(content, forKey: .content)
+            try container.encodeIfPresent(embeds, forKey: .embeds)
+            try container.encodeIfPresent(
+                Payloads.messageFlags(flags, componentsV2: componentsV2),
+                forKey: .flags
+            )
+            try container.encodeIfPresent(allowed_mentions, forKey: .allowed_mentions)
+            if let componentsV2 {
+                try container.encode(componentsV2, forKey: .components)
+            } else {
+                try container.encodeIfPresent(components, forKey: .components)
+            }
+            try container.encodeIfPresent(attachments, forKey: .attachments)
+            try container.encodeIfPresent(poll, forKey: .poll)
         }
 
         public func validate() -> [ValidationFailure] {
@@ -983,9 +1150,38 @@ public enum Payloads {
                 max: 6_000,
                 names: "embeds"
             )
+            validateOnlyContains(
+                flags,
+                name: "flags",
+                reason: "Can only contain 'suppressEmbeds' or 'isComponentsV2'",
+                allowed: [.suppressEmbeds, .isComponentsV2]
+            )
+            validateComponentsV2Payload(
+                components: components,
+                componentsV2: componentsV2,
+                flags: Payloads.messageFlags(flags, componentsV2: componentsV2),
+                hasContent: !(content?.isEmpty ?? true),
+                hasEmbeds: !(embeds?.isEmpty ?? true),
+                hasStickers: false,
+                hasPoll: poll != nil
+            )
+            components != nil && componentsV2 != nil
+                ? ValidationFailure.disallowedField(
+                    name: "components",
+                    reason: "Cannot be used with 'componentsV2'"
+                )
+                : nil
             allowed_mentions?.validate()
             attachments?.validate()
             embeds?.validate()
+            components?.validate()
+            componentsV2?.validate()
+            componentsV2?.validateAsMessageComponents()
+            if let componentsV2 {
+                validateUniqueCustomIDs(componentsV2.customIDs())
+                validateUniqueComponentIDs(componentsV2.componentIDs())
+            }
+            poll?.validate()
         }
     }
 
@@ -1056,6 +1252,7 @@ public enum Payloads {
             public var embeds: [Embed]?
             public var allowed_mentions: AllowedMentions?
             public var components: [Interaction.ActionRow]?
+            public var componentsV2: [Interaction.MessageLayoutComponent]? = nil
             public var sticker_ids: [String]?
             public var files: [RawFile]?
             public var attachments: [Attachment]?
@@ -1095,6 +1292,48 @@ public enum Payloads {
                 self.poll = poll
             }
 
+            public init(
+                content: String? = nil,
+                embeds: [Embed]? = nil,
+                allowed_mentions: AllowedMentions? = nil,
+                componentsV2: [Interaction.MessageLayoutComponent],
+                sticker_ids: [String]? = nil,
+                files: [RawFile]? = nil,
+                attachments: [Attachment]? = nil,
+                flags: IntBitField<DiscordChannel.Message.Flag>? = nil,
+                poll: CreatePollRequest? = nil
+            ) {
+                self.content = content
+                self.embeds = embeds
+                self.allowed_mentions = allowed_mentions
+                self.components = nil
+                self.componentsV2 = componentsV2
+                self.sticker_ids = sticker_ids
+                self.files = files
+                self.attachments = attachments
+                self.flags = Payloads.messageFlags(flags, componentsV2: componentsV2)
+                self.poll = poll
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeIfPresent(content, forKey: .content)
+                try container.encodeIfPresent(embeds, forKey: .embeds)
+                try container.encodeIfPresent(allowed_mentions, forKey: .allowed_mentions)
+                if let componentsV2 {
+                    try container.encode(componentsV2, forKey: .components)
+                } else {
+                    try container.encodeIfPresent(components, forKey: .components)
+                }
+                try container.encodeIfPresent(sticker_ids, forKey: .sticker_ids)
+                try container.encodeIfPresent(attachments, forKey: .attachments)
+                try container.encodeIfPresent(
+                    Payloads.messageFlags(flags, componentsV2: componentsV2),
+                    forKey: .flags
+                )
+                try container.encodeIfPresent(poll, forKey: .poll)
+            }
+
             public func validate() -> [ValidationFailure] {
                 validateElementCountDoesNotExceed(embeds, max: 10, name: "embeds")
                 validateElementCountDoesNotExceed(sticker_ids, max: 3, name: "sticker_ids")
@@ -1105,12 +1344,14 @@ public enum Payloads {
                     embeds?.isEmpty,
                     sticker_ids?.isEmpty,
                     components?.isEmpty,
+                    componentsV2?.isEmpty,
                     files?.isEmpty,
                     poll?.answers.isEmpty,
                     names: "content",
                     "embeds",
                     "sticker_ids",
                     "components",
+                    "componentsV2",
                     "files",
                     "poll"
                 )
@@ -1127,13 +1368,26 @@ public enum Payloads {
                 )
                 validateComponentsV2Payload(
                     components: components,
-                    flags: flags,
+                    componentsV2: componentsV2,
+                    flags: Payloads.messageFlags(flags, componentsV2: componentsV2),
                     hasContent: !(content?.isEmpty ?? true),
                     hasEmbeds: !(embeds?.isEmpty ?? true),
                     hasStickers: !(sticker_ids?.isEmpty ?? true),
                     hasPoll: poll != nil
                 )
+                components != nil && componentsV2 != nil
+                    ? ValidationFailure.disallowedField(
+                        name: "components",
+                        reason: "Cannot be used with 'componentsV2'"
+                    )
+                    : nil
                 components?.validate()
+                componentsV2?.validate()
+                componentsV2?.validateAsMessageComponents()
+                if let componentsV2 {
+                    validateUniqueCustomIDs(componentsV2.customIDs())
+                    validateUniqueComponentIDs(componentsV2.componentIDs())
+                }
                 attachments?.validate()
                 embeds?.validate()
                 poll?.validate()

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -1126,6 +1126,52 @@ class DiscordModelsTests: XCTestCase {
                 """
             let interaction = try JSONDecoder().decode(Interaction.self, from: Data(interactionJSON.utf8))
             XCTAssertEqual(try XCTUnwrap(interaction.message?.componentsV2).count, 1)
+
+            let encodedComponents = try JSONEncoder().encode(IncomingMessageComponents(componentsV2: componentsV2))
+            XCTAssertEqual(
+                try canonicalJSONData(encodedComponents),
+                try canonicalJSONData(
+                    Data(
+                        """
+                        [
+                          {
+                            "type": 17,
+                            "components": [
+                              {
+                                "type": 10,
+                                "content": "Hello"
+                              }
+                            ]
+                          }
+                        ]
+                        """.utf8
+                    )
+                )
+            )
+        }
+
+        do {
+            let json = """
+                [
+                  {
+                    "type": 1,
+                    "components": [
+                      {
+                        "type": 2,
+                        "style": 1,
+                        "label": "Continue",
+                        "custom_id": "continue"
+                      }
+                    ]
+                  }
+                ]
+                """
+            let components = try JSONDecoder().decode(
+                IncomingMessageComponents.self,
+                from: Data(json.utf8)
+            )
+            XCTAssertEqual(components.wrappedValue?.count, 1)
+            XCTAssertNil(components.componentsV2)
         }
     }
 

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -434,6 +434,131 @@ class DiscordModelsTests: XCTestCase {
             )
         }
 
+        func assertMessageLayoutComponentsJSONMatchesConstructed(
+            json: String,
+            _ constructed: [Interaction.MessageLayoutComponent],
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) throws {
+            let decoded = try JSONDecoder().decode(
+                [Interaction.MessageLayoutComponent].self,
+                from: Data(json.utf8)
+            )
+            try assertEncodedJSONEquals(decoded, json: json, file: file, line: line)
+            try assertEncodedJSONEquals(constructed, json: json, file: file, line: line)
+            try assertEncodedJSONEquals(
+                Payloads.CreateMessage(componentsV2: constructed),
+                json: """
+                    {
+                      "flags": 32768,
+                      "components": \(json)
+                    }
+                    """,
+                file: file,
+                line: line
+            )
+        }
+
+        do {
+            let json = """
+                [
+                  {
+                    "type": 9,
+                    "components": [
+                      {
+                        "type": 10,
+                        "content": "Choose an action"
+                      }
+                    ],
+                    "accessory": {
+                      "type": 2,
+                      "style": 1,
+                      "label": "Continue",
+                      "custom_id": "continue"
+                    }
+                  },
+                  {
+                    "type": 12,
+                    "items": [
+                      {
+                        "media": {
+                          "url": "https://example.com/image.png"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": 13,
+                    "file": {
+                      "url": "attachment://report.pdf"
+                    }
+                  },
+                  {
+                    "type": 14,
+                    "divider": true
+                  },
+                  {
+                    "type": 17,
+                    "components": [
+                      {
+                        "type": 10,
+                        "content": "Grouped content"
+                      },
+                      {
+                        "type": 1,
+                        "components": [
+                          {
+                            "type": 2,
+                            "style": 2,
+                            "label": "Cancel",
+                            "custom_id": "cancel"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                """
+
+            let constructed: [Interaction.MessageLayoutComponent] = [
+                .section(
+                    .init(
+                        components: [.textDisplay(.init(content: "Choose an action"))],
+                        accessory: .button(
+                            .init(style: .primary, label: "Continue", custom_id: "continue")
+                        )
+                    )
+                ),
+                .mediaGallery(
+                    .init(items: [.init(media: .init(url: "https://example.com/image.png"))])
+                ),
+                .file(.init(file: .init(url: "attachment://report.pdf"))),
+                .separator(.init(divider: true)),
+                .container(
+                    .init(
+                        componentsV2: [
+                            .textDisplay(.init(content: "Grouped content")),
+                            .actionRow(
+                                .init(
+                                    components: [
+                                        .button(
+                                            .init(
+                                                style: .secondary,
+                                                label: "Cancel",
+                                                custom_id: "cancel"
+                                            )
+                                        )
+                                    ]
+                                )
+                            ),
+                        ]
+                    )
+                ),
+            ]
+
+            try assertMessageLayoutComponentsJSONMatchesConstructed(json: json, constructed)
+        }
+
         do {
             let json = """
                 [
@@ -1171,7 +1296,7 @@ class DiscordModelsTests: XCTestCase {
                 from: Data(json.utf8)
             )
             XCTAssertEqual(components.wrappedValue?.count, 1)
-            XCTAssertNil(components.componentsV2)
+            XCTAssertEqual(components.componentsV2?.count, 1)
         }
     }
 

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -1003,12 +1003,12 @@ class DiscordModelsTests: XCTestCase {
                 "components": [
                   {
                     "type": 18,
-                    "label": "Name",
+                    "id": 1,
                     "component": {
-                      "type": 4,
-                      "custom_id": "name",
-                      "style": 1,
-                      "value": "Nathan"
+                      "type": 21,
+                      "id": 2,
+                      "custom_id": "payment-method",
+                      "value": "bank"
                     }
                   }
                 ]

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -1010,6 +1010,26 @@ class DiscordModelsTests: XCTestCase {
                       "custom_id": "payment-method",
                       "value": "bank"
                     }
+                  },
+                  {
+                    "type": 18,
+                    "id": 3,
+                    "component": {
+                      "type": 22,
+                      "id": 4,
+                      "custom_id": "report-options",
+                      "values": ["payout"]
+                    }
+                  },
+                  {
+                    "type": 18,
+                    "id": 5,
+                    "component": {
+                      "type": 23,
+                      "id": 6,
+                      "custom_id": "confirm",
+                      "value": true
+                    }
                   }
                 ]
               },
@@ -1024,7 +1044,7 @@ class DiscordModelsTests: XCTestCase {
         let submission = try data.requireModalSubmit()
 
         XCTAssertTrue(submission.components.isEmpty)
-        XCTAssertEqual(try XCTUnwrap(submission.componentsV2).count, 1)
+        XCTAssertEqual(try XCTUnwrap(submission.componentsV2).count, 3)
     }
 
     func testInteractionDataUtilities() throws {

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -932,6 +932,64 @@ class DiscordModelsTests: XCTestCase {
             let payload = Payloads.CreateMessage(componentsV2: [.actionRow(actionRow)])
             XCTAssertFalse(payload.validate().isEmpty)
         }
+
+        do {
+            let json = """
+                {
+                  "id": "1",
+                  "channel_id": "2",
+                  "content": "",
+                  "timestamp": "2026-08-05T00:00:00.000000+00:00",
+                  "tts": false,
+                  "mention_everyone": false,
+                  "mentions": [],
+                  "mention_roles": [],
+                  "attachments": [],
+                  "embeds": [],
+                  "pinned": false,
+                  "type": 0,
+                  "flags": 32768,
+                  "components": [
+                    {
+                      "type": 17,
+                      "components": [
+                        {
+                          "type": 10,
+                          "content": "Hello"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """
+
+            let message = try JSONDecoder().decode(DiscordChannel.Message.self, from: Data(json.utf8))
+            XCTAssertNil(message.components)
+            let componentsV2 = try XCTUnwrap(message.componentsV2)
+            XCTAssertEqual(componentsV2.count, 1)
+            guard case let .component(.container(container)) = componentsV2[0] else {
+                return XCTFail("Expected a Container component")
+            }
+            XCTAssertEqual(container.componentsV2?.count, 1)
+
+            let interactionJSON = """
+                {
+                  "id": "3",
+                  "application_id": "4",
+                  "type": 3,
+                  "data": {
+                    "custom_id": "continue",
+                    "component_type": 2
+                  },
+                  "token": "token",
+                  "version": 1,
+                  "entitlements": [],
+                  "message": \(json)
+                }
+                """
+            let interaction = try JSONDecoder().decode(Interaction.self, from: Data(interactionJSON.utf8))
+            XCTAssertEqual(try XCTUnwrap(interaction.message?.componentsV2).count, 1)
+        }
     }
 
     func testInteractionDataUtilities() throws {

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -417,6 +417,23 @@ class DiscordModelsTests: XCTestCase {
             try assertEncodedJSONEquals(constructed, json: json, file: file, line: line)
         }
 
+        func assertComponentsV2Payload<T: Encodable>(_ payload: T) throws {
+            try assertEncodedJSONEquals(
+                payload,
+                json: """
+                    {
+                      "flags": 32768,
+                      "components": [
+                        {
+                          "type": 10,
+                          "content": "Hello"
+                        }
+                      ]
+                    }
+                    """
+            )
+        }
+
         do {
             let json = """
                 [
@@ -934,6 +951,72 @@ class DiscordModelsTests: XCTestCase {
         }
 
         do {
+            let payload = Payloads.CreateMessage(
+                componentsV2: (0..<40).map { .textDisplay(.init(content: "Text \($0)")) }
+            )
+
+            XCTAssertTrue(payload.validate().isEmpty)
+        }
+
+        do {
+            let payload = Payloads.CreateMessage(
+                componentsV2: [
+                    .section(
+                        .init(
+                            components: [
+                                .button(
+                                    .init(style: .primary, label: "Not text", custom_id: "not-text")
+                                )
+                            ],
+                            accessory: .textDisplay(.init(content: "Not an accessory"))
+                        )
+                    )
+                ]
+            )
+
+            XCTAssertFalse(payload.validate().isEmpty)
+        }
+
+        do {
+            let payload = Payloads.CreateMessage(
+                componentsV2: [
+                    .textDisplay(.init(id: 1, content: "First")),
+                    .textDisplay(.init(id: 1, content: "Second")),
+                ]
+            )
+
+            XCTAssertFalse(payload.validate().isEmpty)
+        }
+
+        do {
+            var components = IncomingMessageComponents(
+                componentsV2: [.textDisplay(.init(content: "Components V2"))]
+            )
+            components.wrappedValue = []
+
+            XCTAssertNil(components.componentsV2)
+        }
+
+        do {
+            let payload = Payloads.EditWebhookMessage(
+                componentsV2: [.textDisplay(.init(content: "Hello"))]
+            )
+
+            try assertComponentsV2Payload(payload)
+            try assertComponentsV2Payload(
+                Payloads.EditMessage(componentsV2: [.textDisplay(.init(content: "Hello"))])
+            )
+            try assertComponentsV2Payload(
+                Payloads.ExecuteWebhook(componentsV2: [.textDisplay(.init(content: "Hello"))])
+            )
+            try assertComponentsV2Payload(
+                Payloads.CreateThreadInForumChannel.ForumMessage(
+                    componentsV2: [.textDisplay(.init(content: "Hello"))]
+                )
+            )
+        }
+
+        do {
             let json = """
                 {
                   "id": "1",
@@ -971,6 +1054,41 @@ class DiscordModelsTests: XCTestCase {
                 return XCTFail("Expected a Container component")
             }
             XCTAssertEqual(container.componentsV2?.count, 1)
+
+            let actionRowJSON = """
+                {
+                  "id": "5",
+                  "channel_id": "2",
+                  "content": "",
+                  "timestamp": "2026-08-05T00:00:00.000000+00:00",
+                  "tts": false,
+                  "mention_everyone": false,
+                  "mentions": [],
+                  "mention_roles": [],
+                  "attachments": [],
+                  "embeds": [],
+                  "pinned": false,
+                  "type": 0,
+                  "flags": 32768,
+                  "components": [
+                    {
+                      "type": 1,
+                      "components": [
+                        {
+                          "type": 2,
+                          "style": 1,
+                          "custom_id": "continue"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """
+            let actionRowMessage = try JSONDecoder().decode(
+                DiscordChannel.Message.self,
+                from: Data(actionRowJSON.utf8)
+            )
+            XCTAssertEqual(actionRowMessage.componentsV2?.count, 1)
 
             let interactionJSON = """
                 {

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -847,6 +847,25 @@ class DiscordModelsTests: XCTestCase {
         }
 
         do {
+            let payload = Payloads.InteractionResponse.Modal(
+                custom_id: "feedback",
+                title: "Feedback",
+                componentsV2: [
+                    .label(
+                        .init(
+                            label: "How was your experience?",
+                            component: .textInput(
+                                .init(custom_id: "experience", label: "Experience")
+                            )
+                        )
+                    )
+                ]
+            )
+
+            XCTAssertFalse(payload.validate().isEmpty)
+        }
+
+        do {
             let payload = Payloads.InteractionResponse.Message(
                 componentsV2: [.textDisplay(.init(content: "Hello"))]
             )

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -1167,6 +1167,16 @@ class DiscordModelsTests: XCTestCase {
                       "custom_id": "confirm",
                       "value": true
                     }
+                  },
+                  {
+                    "type": 18,
+                    "id": 7,
+                    "component": {
+                      "type": 3,
+                      "id": 8,
+                      "custom_id": "favourite-colour",
+                      "values": ["blue"]
+                    }
                   }
                 ]
               },
@@ -1181,7 +1191,16 @@ class DiscordModelsTests: XCTestCase {
         let submission = try data.requireModalSubmit()
 
         XCTAssertTrue(submission.components.isEmpty)
-        XCTAssertEqual(try XCTUnwrap(submission.componentsV2).count, 3)
+        let components = try XCTUnwrap(submission.componentsV2)
+        XCTAssertEqual(components.count, 4)
+
+        guard case let .label(label) = components[3],
+            case let .stringSelect(stringSelect) = label.component
+        else {
+            return XCTFail("Expected a String Select in the final label")
+        }
+        XCTAssertTrue(stringSelect.options.isEmpty)
+        XCTAssertEqual(stringSelect.values, ["blue"])
     }
 
     func testInteractionDataUtilities() throws {

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -758,6 +758,177 @@ class DiscordModelsTests: XCTestCase {
 
             try assertActionRowsJSONMatchesConstructed(json: json, actionRows)
         }
+
+        do {
+            let payload = Payloads.CreateMessage(
+                componentsV2: [
+                    .container(
+                        .init(components: [.textDisplay(.init(content: "Hello"))])
+                    ),
+                    .separator(.init(divider: true)),
+                ]
+            )
+
+            try assertEncodedJSONEquals(
+                payload,
+                json: """
+                    {
+                      "flags": 32768,
+                      "components": [
+                        {
+                          "type": 17,
+                          "components": [
+                            {
+                              "type": 10,
+                              "content": "Hello"
+                            }
+                          ]
+                        },
+                        {
+                          "type": 14,
+                          "divider": true
+                        }
+                      ]
+                    }
+                    """
+            )
+        }
+
+        do {
+            let payload = Payloads.InteractionResponse.Modal(
+                custom_id: "feedback",
+                title: "Feedback",
+                componentsV2: [
+                    .label(
+                        .init(
+                            label: "How was your experience?",
+                            component: .textInput(.init(custom_id: "experience"))
+                        )
+                    )
+                ]
+            )
+
+            try assertEncodedJSONEquals(
+                payload,
+                json: """
+                    {
+                      "custom_id": "feedback",
+                      "title": "Feedback",
+                      "components": [
+                        {
+                          "type": 18,
+                          "label": "How was your experience?",
+                          "component": {
+                            "type": 4,
+                            "custom_id": "experience"
+                          }
+                        }
+                      ]
+                    }
+                    """
+            )
+        }
+
+        do {
+            let payload = Payloads.InteractionResponse.Message(
+                componentsV2: [.textDisplay(.init(content: "Hello"))]
+            )
+
+            try assertEncodedJSONEquals(
+                payload,
+                json: """
+                    {
+                      "flags": 32768,
+                      "components": [
+                        {
+                          "type": 10,
+                          "content": "Hello"
+                        }
+                      ]
+                    }
+                    """
+            )
+        }
+
+        do {
+            let payload = Payloads.CreateMessage(
+                componentsV2: [
+                    .container(
+                        .init(
+                            componentsV2: [
+                                .textDisplay(.init(content: "Choose an action.")),
+                                .actionRow(
+                                    .init(
+                                        components: [
+                                            .button(
+                                                .init(
+                                                    style: .primary,
+                                                    label: "Continue",
+                                                    custom_id: "continue"
+                                                )
+                                            )
+                                        ]
+                                    )
+                                ),
+                            ]
+                        )
+                    )
+                ]
+            )
+
+            try assertEncodedJSONEquals(
+                payload,
+                json: """
+                    {
+                      "flags": 32768,
+                      "components": [
+                        {
+                          "type": 17,
+                          "components": [
+                            {
+                              "type": 10,
+                              "content": "Choose an action."
+                            },
+                            {
+                              "type": 1,
+                              "components": [
+                                {
+                                  "type": 2,
+                                  "label": "Continue",
+                                  "custom_id": "continue",
+                                  "style": 1
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """
+            )
+        }
+
+        do {
+            let payload = Payloads.CreateMessage(
+                componentsV2: [
+                    .component(.button(.init(style: .primary, label: "Continue", custom_id: "continue")))
+                ]
+            )
+
+            XCTAssertFalse(payload.validate().isEmpty)
+        }
+
+        do {
+            let actionRow = Interaction.ActionRow(
+                components: (0..<6).map {
+                    .button(
+                        .init(style: .primary, label: "Button \($0)", custom_id: "button-\($0)")
+                    )
+                }
+            )
+
+            XCTAssertFalse(actionRow.validate().isEmpty)
+        }
     }
 
     func testInteractionDataUtilities() throws {

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -992,6 +992,41 @@ class DiscordModelsTests: XCTestCase {
         }
     }
 
+    func testComponentsV2ModalSubmissionDecoding() throws {
+        let json = """
+            {
+              "id": "1",
+              "application_id": "2",
+              "type": 5,
+              "data": {
+                "custom_id": "modal",
+                "components": [
+                  {
+                    "type": 18,
+                    "label": "Name",
+                    "component": {
+                      "type": 4,
+                      "custom_id": "name",
+                      "style": 1,
+                      "value": "Nathan"
+                    }
+                  }
+                ]
+              },
+              "token": "token",
+              "version": 1,
+              "entitlements": []
+            }
+            """
+
+        let interaction = try JSONDecoder().decode(Interaction.self, from: Data(json.utf8))
+        let data = try XCTUnwrap(interaction.data)
+        let submission = try data.requireModalSubmit()
+
+        XCTAssertTrue(submission.components.isEmpty)
+        XCTAssertEqual(try XCTUnwrap(submission.componentsV2).count, 1)
+    }
+
     func testInteractionDataUtilities() throws {
         let applicationCommand: Interaction.Data = .applicationCommand(
             .init(id: "", name: "", type: .applicationCommand)

--- a/Tests/DiscordBMTests/DiscordModels.swift
+++ b/Tests/DiscordBMTests/DiscordModels.swift
@@ -927,7 +927,10 @@ class DiscordModelsTests: XCTestCase {
                 }
             )
 
-            XCTAssertFalse(actionRow.validate().isEmpty)
+            XCTAssertTrue(actionRow.validate().isEmpty)
+
+            let payload = Payloads.CreateMessage(componentsV2: [.actionRow(actionRow)])
+            XCTAssertFalse(payload.validate().isEmpty)
         }
     }
 


### PR DESCRIPTION
Adding support for ComponentsV2 payloads (messages/embeds).

DiscordBM already models Components V2 types, but there is an issue with the public payload shape.

DiscordBM sends messages using:
``` swift 
Payloads.CreateMessage(
    components: [Interaction.ActionRow]
)
```

Every Interaction.ActionRow is always encoded as:
```swift
{ "type": 1, "components": [...] }
```

That works for legacy buttons/selects, but Components V2 requires arbitrary top-level components:
```swift
{
  "flags": 32768,
  "components": [
    { "type": 17, "components": [...] },
    { "type": 14, "divider": true }
  ]
}
```

So this looks valid in Swift, but produces an invalid Discord payload:
```swift
Interaction.ActionRow(components: [
    .container(.init(components: [
        .textDisplay(.init(content: "Hello"))
    ]))
])
```
It becomes an action row containing a container. Discord requires the container itself at the top level.
